### PR TITLE
Fix BYAML array nodes not aligning types table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ typings/
 .env
 
 # custom
+.DS_Store
 dist
 test
 *.cia

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pretendonetwork/nintendo-files",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "TypeScript library for interacting with several Nintendo file formats across various consoles.",
 	"scripts": {
 		"lint": "npx eslint .",

--- a/src/byaml.ts
+++ b/src/byaml.ts
@@ -347,6 +347,8 @@ export default class BYAML {
 			typeTable.push(nodeType);
 		}
 
+		this.stream.alignBlock(4); // * Types table is padded to a multiple of 4 using null bytes
+
 		const elements: Node[] = [];
 
 		for (const nodeType of typeTable) {


### PR DESCRIPTION
Resolves #XXX

### Changes:

Aligns the array nodes types table to a multiple of 4. Fixes not being able to read Splatoon rotation files and other files which have array nodes with lengths not a multiple of 4

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.